### PR TITLE
Update Apple ifdef preprocessor guards to exclude iPhone platforms

### DIFF
--- a/include/sockaddr_util.h
+++ b/include/sockaddr_util.h
@@ -166,7 +166,9 @@ sockaddr_isAddrSiteLocal(const struct sockaddr* sa);
 bool
 sockaddr_isAddrULA(const struct sockaddr* sa);
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && defined(__MACH__)
+#include <TargetConditionals.h>
+#if TARGET_OS_OSX == 1
 /*
  * Get IPv6 Flags.
  * Will return 0 in case if failure or IPv4 addr
@@ -194,6 +196,7 @@ bool
 sockaddr_isAddrDeprecated(const struct sockaddr* sa,
                           const char*            ifa_name,
                           int                    ifa_len);
+#endif
 #endif
 /*
  * Converts a sockaddr to string

--- a/src/sockaddr_util.c
+++ b/src/sockaddr_util.c
@@ -10,8 +10,11 @@
 #include <netinet/in.h>
 
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && defined(__MACH__)
+#include <TargetConditionals.h>
+#if TARGET_OS_OSX == 1
 #include <netinet/in_var.h>
+#endif
 #endif
 
 
@@ -432,7 +435,9 @@ sockaddr_isAddrULA(const struct sockaddr* sa)
   return false;
 }
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) && defined(__MACH__)
+#include <TargetConditionals.h>
+#if TARGET_OS_OSX == 1
 int
 sockaddr_getIPv6Flags(const struct sockaddr* sa,
                       const char*            ifa_name,
@@ -517,6 +522,7 @@ sockaddr_isAddrDeprecated(const struct sockaddr* sa,
   }
   return false;
 }
+#endif
 #endif
 
 


### PR DESCRIPTION
When building sockaddrutil for iOS and other iPhone derived platforms like tvOS and watchOS, it fails because these SDKs are incomplete with respect to headers such as netinet/in_var.sh and its IPv6 companion.

Example listing from MacOS 10.14 and iPhoneOS 12 SDKs:

`$/Applications/Xcode-10.0.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk/usr/include/netinet$ ls
icmp6.h     in.h        in_pcb.h    in_systm.h  ip.h        ip6.h       ip_icmp.h   tcp.h       tcp_timer.h tcp_var.h   udp.h`

`:/Applications/Xcode-10.0.0.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/netinet$ ls
bootp.h     icmp6.h     icmp_var.h  if_ether.h  igmp.h      igmp_var.h  in.h        in_pcb.h    in_systm.h  in_var.h    ip.h        ip6.h       ip_icmp.h   ip_var.h    tcp.h       tcp_fsm.h   tcp_seq.h   tcp_timer.h tcp_var.h   tcpip.h     udp.h       udp_var.h`

Searching for an example symbol that is used in sockaddrutil, `in6_ifreq`, it exists in the following placs in MacOSX.sdk:
`System/Library/Frameworks/Kernel.framework/Headers/netinet6/in6_var.h`
`usr/include/netinet6/in6_var.h`

But it doesn't exist at all in iPhoneOS.sdk.

For those only needing some functions in sockaddrutil, excluding those that work only for the Mac makes the library useable on iOS, so I've updated the include guards to target the Mac specifically on this branch. I've also added a test for MACH which, whilst this lib isn't going to be compiled on Mac OS 9 ever, is technically the correct way to test for OS X-derived platforms.